### PR TITLE
changes to provide optionals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 .idea/*
 target/
+*.classpath
+*.project
+*.settings/
 *.iml
 *.ipr
 *.iws

--- a/src/main/java/com/flipkart/databuilderframework/annotations/DataBuilderClassInfo.java
+++ b/src/main/java/com/flipkart/databuilderframework/annotations/DataBuilderClassInfo.java
@@ -13,4 +13,5 @@ public @interface DataBuilderClassInfo {
     public String name() default "";
     public Class<? extends Data> produces();
     public Class<? extends Data>[] consumes();
+    public Class<? extends Data>[] optionals() default {};
 }

--- a/src/main/java/com/flipkart/databuilderframework/annotations/DataBuilderInfo.java
+++ b/src/main/java/com/flipkart/databuilderframework/annotations/DataBuilderInfo.java
@@ -13,5 +13,6 @@ import java.lang.annotation.Target;
 public @interface DataBuilderInfo {
     public String name();
     public String[] consumes();
+    public String[] optionals() default {}; //optionally consumer
     public String produces();
 }

--- a/src/main/java/com/flipkart/databuilderframework/engine/DataBuilderMetaUtil.java
+++ b/src/main/java/com/flipkart/databuilderframework/engine/DataBuilderMetaUtil.java
@@ -1,0 +1,23 @@
+package com.flipkart.databuilderframework.engine;
+
+import java.util.Set;
+
+import com.flipkart.databuilderframework.model.DataBuilderMeta;
+import com.google.common.collect.Sets;
+
+/**
+ * Utility class to DataBuilderMetaD
+ * @author gokulvanan.v
+ *
+ */
+public class DataBuilderMetaUtil {
+
+
+	public  static Set<String> getEffectiveConsumes(DataBuilderMeta builderMeta){
+		if(null == builderMeta.getOptionals() && builderMeta.getOptionals().isEmpty()){
+			return builderMeta.getConsumes();
+		}else{
+			return Sets.union(builderMeta.getConsumes(), builderMeta.getOptionals());
+		}
+	}
+}

--- a/src/main/java/com/flipkart/databuilderframework/engine/DataFlowBuilder.java
+++ b/src/main/java/com/flipkart/databuilderframework/engine/DataFlowBuilder.java
@@ -66,8 +66,9 @@ public class DataFlowBuilder {
      */
     public DataFlowBuilder withDataBuilder(String produces,
                                            Set<String> consumes,
+                                           Set<String> optionals,
                                            Class<? extends DataBuilder> dataBuilder) throws DataBuilderFrameworkException {
-        return withDataBuilder(dataBuilder.getSimpleName(), produces, consumes, dataBuilder);
+        return withDataBuilder(dataBuilder.getSimpleName(), produces, consumes, optionals, dataBuilder);
     }
 
     /**
@@ -81,8 +82,9 @@ public class DataFlowBuilder {
     public DataFlowBuilder withDataBuilder(String name,
                                            String produces,
                                            Set<String> consumes,
+                                           Set<String> optionals,
                                            Class<? extends DataBuilder> dataBuilder) throws DataBuilderFrameworkException {
-        return withDataBuilder(name, produces, consumes, dataBuilder, false);
+        return withDataBuilder(name, produces,optionals, consumes, dataBuilder, false);
     }
 
     /**
@@ -97,9 +99,10 @@ public class DataFlowBuilder {
     public DataFlowBuilder withDataBuilder(String name,
                                            String produces,
                                            Set<String> consumes,
+                                           Set<String> optionals,
                                            Class<? extends DataBuilder> dataBuilder,
                                            boolean isTransient) throws DataBuilderFrameworkException {
-        dataBuilderMetadataManager.register(consumes, produces, name, dataBuilder);
+        dataBuilderMetadataManager.register(consumes,optionals, produces, name, dataBuilder);
         if(isTransient) {
             dataFlow.getTransients().add(name);
         }
@@ -127,8 +130,9 @@ public class DataFlowBuilder {
      */
     public DataFlowBuilder withDataBuilder(String produces,
                                            Set<String> consumes,
+                                           Set<String> optionals,
                                            DataBuilder dataBuilder) throws DataBuilderFrameworkException {
-        return withDataBuilder(dataBuilder.getClass().getSimpleName(), produces, consumes, dataBuilder);
+        return withDataBuilder(dataBuilder.getClass().getSimpleName(), produces, consumes, optionals, dataBuilder);
     }
 
     /**
@@ -142,8 +146,9 @@ public class DataFlowBuilder {
     public DataFlowBuilder withDataBuilder(String name,
                                            String produces,
                                            Set<String> consumes,
+                                           Set<String> optionals,
                                            DataBuilder dataBuilder) throws DataBuilderFrameworkException {
-        return withDataBuilder(name, produces, consumes, dataBuilder, false);
+        return withDataBuilder(name, produces, consumes, optionals, dataBuilder, false);
     }
 
     /**
@@ -158,9 +163,10 @@ public class DataFlowBuilder {
     public DataFlowBuilder withDataBuilder(String name,
                                            String produces,
                                            Set<String> consumes,
+                                           Set<String> optionals,
                                            DataBuilder dataBuilder,
                                            boolean isTransient) throws DataBuilderFrameworkException {
-        DataBuilderMeta dataBuilderMeta = new DataBuilderMeta(consumes, produces, name);
+        DataBuilderMeta dataBuilderMeta = new DataBuilderMeta(consumes, optionals, produces, name);
         if(isTransient) {
             dataFlow.getTransients().add(name);
         }
@@ -184,6 +190,7 @@ public class DataFlowBuilder {
         if(null != info) {
             dataBuilderMeta = new DataBuilderMeta(
                     ImmutableSet.copyOf(info.consumes()),
+                    ImmutableSet.copyOf(info.optionals()),
                     info.produces(),
                     info.name());
         }
@@ -195,8 +202,13 @@ public class DataFlowBuilder {
             for(Class<? extends Data> data : dataBuilderClassInfo.consumes()) {
                 consumes.add(data.getCanonicalName());
             }
+            Set<String> optionals = Sets.newHashSet();
+            for(Class<? extends Data> data : dataBuilderClassInfo.optionals()) {
+                optionals.add(data.getCanonicalName());
+            }
             dataBuilderMeta = new DataBuilderMeta(
                     ImmutableSet.copyOf(consumes),
+                    ImmutableSet.copyOf(optionals),
                     dataBuilderClassInfo.produces().getCanonicalName(),
                     Strings.isNullOrEmpty(dataBuilderClassInfo.name())
                             ? annotatedDataBuilder.getCanonicalName()

--- a/src/main/java/com/flipkart/databuilderframework/engine/DataFlowBuilder.java
+++ b/src/main/java/com/flipkart/databuilderframework/engine/DataFlowBuilder.java
@@ -66,6 +66,21 @@ public class DataFlowBuilder {
      */
     public DataFlowBuilder withDataBuilder(String produces,
                                            Set<String> consumes,
+                                           Class<? extends DataBuilder> dataBuilder) throws DataBuilderFrameworkException {
+        return withDataBuilder(dataBuilder.getSimpleName(), produces, consumes,dataBuilder);
+    }
+
+    /**
+     * Register an unnamed,  unannotated builder class.
+     * @param produces Name of the data that this builder produces.
+     * @param consumes Names of the data that this class consumes.
+     * @param optionals Names of the data that this class optionally consumes
+     * @param dataBuilder Builder class to be used. Class must have a no-args constructor.
+     * @return
+     * @throws DataBuilderFrameworkException
+     */
+    public DataFlowBuilder withDataBuilder(String produces,
+                                           Set<String> consumes,
                                            Set<String> optionals,
                                            Class<? extends DataBuilder> dataBuilder) throws DataBuilderFrameworkException {
         return withDataBuilder(dataBuilder.getSimpleName(), produces, consumes, optionals, dataBuilder);
@@ -82,6 +97,22 @@ public class DataFlowBuilder {
     public DataFlowBuilder withDataBuilder(String name,
                                            String produces,
                                            Set<String> consumes,
+                                           Class<? extends DataBuilder> dataBuilder) throws DataBuilderFrameworkException {
+        return withDataBuilder(name, produces, consumes, dataBuilder, false);
+    }
+    
+    /**
+     * Register a named, unannotated builder class.
+     * @param produces Name of the data that this builder produces.
+     * @param consumes Names of the data that this class consumes.
+     * @param optionals Names of the data that this class optionaly consumes.
+     * @param dataBuilder Builder class to be used. Class must have a no-args constructor.
+     * @return
+     * @throws DataBuilderFrameworkException
+     */
+    public DataFlowBuilder withDataBuilder(String name,
+                                           String produces,
+                                           Set<String> consumes,
                                            Set<String> optionals,
                                            Class<? extends DataBuilder> dataBuilder) throws DataBuilderFrameworkException {
         return withDataBuilder(name, produces,optionals, consumes, dataBuilder, false);
@@ -91,6 +122,28 @@ public class DataFlowBuilder {
      * Register a unannotated builder class.
      * @param produces Name of the data that this builder produces.
      * @param consumes Names of the data that this class consumes.
+     * @param dataBuilder Builder class to be used. Class must have a no-args constructor.
+     * @param isTransient Data produced by this class is transient and will not be a part of the data-set.
+     * @return
+     * @throws DataBuilderFrameworkException
+     */
+    public DataFlowBuilder withDataBuilder(String name,
+                                           String produces,
+                                           Set<String> consumes,
+                                           Class<? extends DataBuilder> dataBuilder,
+                                           boolean isTransient) throws DataBuilderFrameworkException {
+        dataBuilderMetadataManager.register(consumes, produces, name, dataBuilder);
+        if(isTransient) {
+            dataFlow.getTransients().add(name);
+        }
+        return this;
+    }
+
+    /**
+     * Register a unannotated builder class.
+     * @param produces  Name of the data that this builder produces.
+     * @param consumes  Names of the data that this class consumes.
+     * @param optionals Names of the data that this class optionaly consumes. 
      * @param dataBuilder Builder class to be used. Class must have a no-args constructor.
      * @param isTransient Data produced by this class is transient and will not be a part of the data-set.
      * @return

--- a/src/main/java/com/flipkart/databuilderframework/engine/DataSetAccessor.java
+++ b/src/main/java/com/flipkart/databuilderframework/engine/DataSetAccessor.java
@@ -1,6 +1,7 @@
 package com.flipkart.databuilderframework.engine;
 
 import com.flipkart.databuilderframework.model.Data;
+import com.flipkart.databuilderframework.model.DataBuilderMeta;
 import com.flipkart.databuilderframework.model.DataDelta;
 import com.flipkart.databuilderframework.model.DataSet;
 import com.google.common.base.Optional;
@@ -56,10 +57,11 @@ public class DataSetAccessor {
      * @return data
      */
     public <B extends DataBuilder, T extends Data> T getAccessibleData(String key, B builder, Class<T> tClass) {
-    	Preconditions.checkArgument(!builder.getDataBuilderMeta().getCumilativeConsumes().contains(key),
+    	DataBuilderMeta meta  = builder.getDataBuilderMeta();
+    	Preconditions.checkArgument(!meta.getEffectiveConsumes().contains(key),
                             String.format("Builder %s can access only %s",
                                             builder.getDataBuilderMeta().getName(),
-                                            builder.getDataBuilderMeta().getCumilativeConsumes()));
+                                            meta.getEffectiveConsumes()));
         return get(key, tClass);
     }
 
@@ -69,8 +71,9 @@ public class DataSetAccessor {
      * @return
      */
     public DataSet getAccesibleDataSetFor(DataBuilder builder) {
+    	DataBuilderMeta meta  = builder.getDataBuilderMeta();
         return new DataSet(Maps.filterKeys(dataSet.getAvailableData(),
-                                    Predicates.in(builder.getDataBuilderMeta().getCumilativeConsumes())));
+                                    Predicates.in(meta.getEffectiveConsumes())));
     }
 
     /**

--- a/src/main/java/com/flipkart/databuilderframework/engine/DataSetAccessor.java
+++ b/src/main/java/com/flipkart/databuilderframework/engine/DataSetAccessor.java
@@ -28,9 +28,6 @@ public class DataSetAccessor {
         return get(tClass.getCanonicalName(), tClass);
     }
     
-    public <T extends Data> Optional<T> getOptional(Class<T> tClass) {
-        return getOptional(tClass.getCanonicalName(), tClass);
-    }
     
     /**
      * Get a data from {@link com.flipkart.databuilderframework.model.DataSet}.
@@ -48,21 +45,6 @@ public class DataSetAccessor {
         return null;
     }
     
-    /**
-     * Get a optional data from {@link com.flipkart.databuilderframework.model.DataSet}.
-     * @param key Key for the data
-     * @param tClass Class to cast the data to. Should inherit from {@link com.flipkart.databuilderframework.model.Data}
-     * @param <T> Sub-Type for {@link com.flipkart.databuilderframework.model.Data}. Should be same as <i>tClass</i>
-     * @return data
-     */
-    public <T extends Data> Optional<T> getOptional(String key, Class<T> tClass) {
-        Map<String, Data> availableData = dataSet.getAvailableData();
-        if(availableData.containsKey(key)) {
-            Data data = availableData.get(key);
-            return Optional.of(tClass.cast(data));
-        }
-        return Optional.absent();
-    }
 
     /**
      * Get data from {@link com.flipkart.databuilderframework.model.DataSet}, with accessibility checks.
@@ -131,6 +113,15 @@ public class DataSetAccessor {
      */
     public boolean checkForData(String data) {
         return dataSet.getAvailableData().containsKey(data);
+    }
+    
+    /**
+     * Check if a specified data is present in the {@link com.flipkart.databuilderframework.model.DataSet}
+     * @param Class of data expected (defaults to cannonical name when DataAdapter is in use
+     * @return <i>true</i> if all elements are present. <i>false</i> otherwise.
+     */
+    public boolean checkForData(Class<? extends Data> dataClass) {
+        return dataSet.getAvailableData().containsKey(dataClass.getCanonicalName());
     }
 
     /**

--- a/src/main/java/com/flipkart/databuilderframework/engine/DataSetAccessor.java
+++ b/src/main/java/com/flipkart/databuilderframework/engine/DataSetAccessor.java
@@ -57,11 +57,11 @@ public class DataSetAccessor {
      * @return data
      */
     public <B extends DataBuilder, T extends Data> T getAccessibleData(String key, B builder, Class<T> tClass) {
-    	DataBuilderMeta meta  = builder.getDataBuilderMeta();
-    	Preconditions.checkArgument(!meta.getEffectiveConsumes().contains(key),
+    	Set<String> effectiveConsumes = DataBuilderMetaUtil.getEffectiveConsumes(builder.getDataBuilderMeta());
+    	Preconditions.checkArgument(!effectiveConsumes.contains(key),
                             String.format("Builder %s can access only %s",
                                             builder.getDataBuilderMeta().getName(),
-                                            meta.getEffectiveConsumes()));
+                                           effectiveConsumes));
         return get(key, tClass);
     }
 
@@ -71,9 +71,9 @@ public class DataSetAccessor {
      * @return
      */
     public DataSet getAccesibleDataSetFor(DataBuilder builder) {
-    	DataBuilderMeta meta  = builder.getDataBuilderMeta();
-        return new DataSet(Maps.filterKeys(dataSet.getAvailableData(),
-                                    Predicates.in(meta.getEffectiveConsumes())));
+    	Set<String> effectiveConsumes = DataBuilderMetaUtil.getEffectiveConsumes(builder.getDataBuilderMeta());
+    	return new DataSet(Maps.filterKeys(dataSet.getAvailableData(),
+                                    Predicates.in(effectiveConsumes)));
     }
 
     /**

--- a/src/main/java/com/flipkart/databuilderframework/engine/MultiThreadedDataFlowExecutor.java
+++ b/src/main/java/com/flipkart/databuilderframework/engine/MultiThreadedDataFlowExecutor.java
@@ -58,12 +58,12 @@ public class MultiThreadedDataFlowExecutor extends DataFlowExecutor {
                         continue;
                     }
                     //If there is an intersection, means some of it's inputs have changed. Reevaluate
-                    Set<String> effectiveConsumes = builderMeta.getEffectiveConsumes();
+                    Set<String> effectiveConsumes = DataBuilderMetaUtil.getEffectiveConsumes(builderMeta);
                     if (Sets.intersection(effectiveConsumes, activeDataSet).isEmpty()) {
                         continue;
                     }
                     DataBuilder builder = builderFactory.create(builderMeta.getName());
-                    if (!dataSetAccessor.checkForData(effectiveConsumes)) {
+                    if (!dataSetAccessor.checkForData(builderMeta.getConsumes())) {
                         break; //No need to run others, list is topo sorted
                     }
                     BuilderRunner builderRunner = new BuilderRunner(dataBuilderExecutionListener, dataFlowInstance,

--- a/src/main/java/com/flipkart/databuilderframework/engine/MultiThreadedDataFlowExecutor.java
+++ b/src/main/java/com/flipkart/databuilderframework/engine/MultiThreadedDataFlowExecutor.java
@@ -58,11 +58,12 @@ public class MultiThreadedDataFlowExecutor extends DataFlowExecutor {
                         continue;
                     }
                     //If there is an intersection, means some of it's inputs have changed. Reevaluate
-                    if (Sets.intersection(builderMeta.getCumilativeConsumes(), activeDataSet).isEmpty()) {
+                    Set<String> effectiveConsumes = builderMeta.getEffectiveConsumes();
+                    if (Sets.intersection(effectiveConsumes, activeDataSet).isEmpty()) {
                         continue;
                     }
                     DataBuilder builder = builderFactory.create(builderMeta.getName());
-                    if (!dataSetAccessor.checkForData(builder.getDataBuilderMeta().getCumilativeConsumes())) {
+                    if (!dataSetAccessor.checkForData(effectiveConsumes)) {
                         break; //No need to run others, list is topo sorted
                     }
                     BuilderRunner builderRunner = new BuilderRunner(dataBuilderExecutionListener, dataFlowInstance,

--- a/src/main/java/com/flipkart/databuilderframework/engine/MultiThreadedDataFlowExecutor.java
+++ b/src/main/java/com/flipkart/databuilderframework/engine/MultiThreadedDataFlowExecutor.java
@@ -58,11 +58,11 @@ public class MultiThreadedDataFlowExecutor extends DataFlowExecutor {
                         continue;
                     }
                     //If there is an intersection, means some of it's inputs have changed. Reevaluate
-                    if (Sets.intersection(builderMeta.getConsumes(), activeDataSet).isEmpty()) {
+                    if (Sets.intersection(builderMeta.getCumilativeConsumes(), activeDataSet).isEmpty()) {
                         continue;
                     }
                     DataBuilder builder = builderFactory.create(builderMeta.getName());
-                    if (!dataSetAccessor.checkForData(builder.getDataBuilderMeta().getConsumes())) {
+                    if (!dataSetAccessor.checkForData(builder.getDataBuilderMeta().getCumilativeConsumes())) {
                         break; //No need to run others, list is topo sorted
                     }
                     BuilderRunner builderRunner = new BuilderRunner(dataBuilderExecutionListener, dataFlowInstance,

--- a/src/main/java/com/flipkart/databuilderframework/engine/SimpleDataFlowExecutor.java
+++ b/src/main/java/com/flipkart/databuilderframework/engine/SimpleDataFlowExecutor.java
@@ -54,12 +54,12 @@ public class SimpleDataFlowExecutor extends DataFlowExecutor {
                         continue;
                     }
                     //If there is an intersection, means some of it's inputs have changed. Reevaluate
-                    Set<String> effectiveConsumes = builderMeta.getEffectiveConsumes(); 
+                    Set<String> effectiveConsumes = DataBuilderMetaUtil.getEffectiveConsumes(builderMeta);
                     if (Sets.intersection(effectiveConsumes, activeDataSet).isEmpty()) {
                         continue;
                     }
                     DataBuilder builder = builderFactory.create(builderMeta.getName());
-                    if (!dataSetAccessor.checkForData(effectiveConsumes)) {
+                    if (!dataSetAccessor.checkForData(builderMeta.getConsumes())) {
                         break; //No need to run others, list is topo sorted
                     }
                     for (DataBuilderExecutionListener listener : dataBuilderExecutionListener) {

--- a/src/main/java/com/flipkart/databuilderframework/engine/SimpleDataFlowExecutor.java
+++ b/src/main/java/com/flipkart/databuilderframework/engine/SimpleDataFlowExecutor.java
@@ -54,11 +54,11 @@ public class SimpleDataFlowExecutor extends DataFlowExecutor {
                         continue;
                     }
                     //If there is an intersection, means some of it's inputs have changed. Reevaluate
-                    if (Sets.intersection(builderMeta.getConsumes(), activeDataSet).isEmpty()) {
+                    if (Sets.intersection(builderMeta.getCumilativeConsumes(), activeDataSet).isEmpty()) {
                         continue;
                     }
                     DataBuilder builder = builderFactory.create(builderMeta.getName());
-                    if (!dataSetAccessor.checkForData(builder.getDataBuilderMeta().getConsumes())) {
+                    if (!dataSetAccessor.checkForData(builder.getDataBuilderMeta().getCumilativeConsumes())) {
                         break; //No need to run others, list is topo sorted
                     }
                     for (DataBuilderExecutionListener listener : dataBuilderExecutionListener) {

--- a/src/main/java/com/flipkart/databuilderframework/engine/SimpleDataFlowExecutor.java
+++ b/src/main/java/com/flipkart/databuilderframework/engine/SimpleDataFlowExecutor.java
@@ -54,11 +54,12 @@ public class SimpleDataFlowExecutor extends DataFlowExecutor {
                         continue;
                     }
                     //If there is an intersection, means some of it's inputs have changed. Reevaluate
-                    if (Sets.intersection(builderMeta.getCumilativeConsumes(), activeDataSet).isEmpty()) {
+                    Set<String> effectiveConsumes = builderMeta.getEffectiveConsumes(); 
+                    if (Sets.intersection(effectiveConsumes, activeDataSet).isEmpty()) {
                         continue;
                     }
                     DataBuilder builder = builderFactory.create(builderMeta.getName());
-                    if (!dataSetAccessor.checkForData(builder.getDataBuilderMeta().getCumilativeConsumes())) {
+                    if (!dataSetAccessor.checkForData(effectiveConsumes)) {
                         break; //No need to run others, list is topo sorted
                     }
                     for (DataBuilderExecutionListener listener : dataBuilderExecutionListener) {

--- a/src/main/java/com/flipkart/databuilderframework/model/DataBuilderMeta.java
+++ b/src/main/java/com/flipkart/databuilderframework/model/DataBuilderMeta.java
@@ -35,12 +35,6 @@ public class DataBuilderMeta implements Comparable<DataBuilderMeta>, Serializabl
     @JsonProperty
     private Set<String> optionals;
     
-    /**
-     * List of {@link com.flipkart.databuilderframework.model.Data} this {@link com.flipkart.databuilderframework.engine.DataBuilder}
-     * that is union of consumes and optional.
-     */
-    private Set<String> cumilativeConsumes;
-
     
     /**
      * {@link com.flipkart.databuilderframework.model.Data} this {@link com.flipkart.databuilderframework.engine.DataBuilder} generates.
@@ -66,18 +60,11 @@ public class DataBuilderMeta implements Comparable<DataBuilderMeta>, Serializabl
         this.optionals = optionals;
         this.produces = produces;
         this.name = name;
-        this.cumilativeConsumes = Sets.union(consumes, optionals);
     }
 
     public DataBuilderMeta() {
     }
 
-    public Set<String> getCumilativeConsumes() {
-    	if(cumilativeConsumes == null){ //for case when it not initialized from constrcutor
-    		cumilativeConsumes = Sets.union(consumes, optionals);
-    	}
-        return cumilativeConsumes;
-    }
 
     public Set<String> getConsumes() {
         return consumes;
@@ -85,6 +72,14 @@ public class DataBuilderMeta implements Comparable<DataBuilderMeta>, Serializabl
 
     public Set<String> getOptionals() {
         return optionals;
+    }
+    
+    public Set<String> getEffectiveConsumes(){
+    	if(null == optionals && optionals.isEmpty()){
+    		return consumes;
+    	}else{
+    		return Sets.union(consumes, optionals);
+    	}
     }
 
     public String getProduces() {

--- a/src/main/java/com/flipkart/databuilderframework/model/DataBuilderMeta.java
+++ b/src/main/java/com/flipkart/databuilderframework/model/DataBuilderMeta.java
@@ -73,14 +73,6 @@ public class DataBuilderMeta implements Comparable<DataBuilderMeta>, Serializabl
     public Set<String> getOptionals() {
         return optionals;
     }
-    
-    public Set<String> getEffectiveConsumes(){
-    	if(null == optionals && optionals.isEmpty()){
-    		return consumes;
-    	}else{
-    		return Sets.union(consumes, optionals);
-    	}
-    }
 
     public String getProduces() {
         return produces;

--- a/src/main/java/com/flipkart/databuilderframework/model/DataBuilderMeta.java
+++ b/src/main/java/com/flipkart/databuilderframework/model/DataBuilderMeta.java
@@ -2,9 +2,12 @@ package com.flipkart.databuilderframework.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+
 import org.hibernate.validator.constraints.NotEmpty;
 
 import javax.validation.constraints.NotNull;
+
 import java.io.Serializable;
 import java.util.Set;
 
@@ -24,6 +27,22 @@ public class DataBuilderMeta implements Comparable<DataBuilderMeta>, Serializabl
     private Set<String> consumes;
 
     /**
+     * List of {@link com.flipkart.databuilderframework.model.Data} this {@link com.flipkart.databuilderframework.engine.DataBuilder}
+     * optional.
+     */
+    @NotNull
+    @NotEmpty
+    @JsonProperty
+    private Set<String> optionals;
+    
+    /**
+     * List of {@link com.flipkart.databuilderframework.model.Data} this {@link com.flipkart.databuilderframework.engine.DataBuilder}
+     * that is union of consumes and optional.
+     */
+    private Set<String> cumilativeConsumes;
+
+    
+    /**
      * {@link com.flipkart.databuilderframework.model.Data} this {@link com.flipkart.databuilderframework.engine.DataBuilder} generates.
      */
     @NotNull
@@ -41,17 +60,31 @@ public class DataBuilderMeta implements Comparable<DataBuilderMeta>, Serializabl
 
     private int rank;
 
-    public DataBuilderMeta(Set<String> consumes, String produces, String name) {
+    public DataBuilderMeta(Set<String> consumes, Set<String> optionals,
+    		String produces, String name) {
         this.consumes = consumes;
+        this.optionals = optionals;
         this.produces = produces;
         this.name = name;
+        this.cumilativeConsumes = Sets.union(consumes, optionals);
     }
 
     public DataBuilderMeta() {
     }
 
+    public Set<String> getCumilativeConsumes() {
+    	if(cumilativeConsumes == null){ //for case when it not initialized from constrcutor
+    		cumilativeConsumes = Sets.union(consumes, optionals);
+    	}
+        return cumilativeConsumes;
+    }
+
     public Set<String> getConsumes() {
         return consumes;
+    }
+
+    public Set<String> getOptionals() {
+        return optionals;
     }
 
     public String getProduces() {
@@ -76,6 +109,7 @@ public class DataBuilderMeta implements Comparable<DataBuilderMeta>, Serializabl
         if (!consumes.equals(that.consumes)) return false;
         if (!name.equals(that.name)) return false;
         if (!produces.equals(that.produces)) return false;
+        if(!optionals.equals(that.optionals)) return false;
 
         return true;
     }
@@ -84,18 +118,24 @@ public class DataBuilderMeta implements Comparable<DataBuilderMeta>, Serializabl
     public int hashCode() {
         int result = consumes.hashCode();
         result = 31 * result + produces.hashCode();
+        result = 31 * result + optionals.hashCode();
         result = 31 * result + name.hashCode();
         return result;
     }
 
     public DataBuilderMeta deepCopy() {
-        return new DataBuilderMeta(ImmutableSet.copyOf(consumes), produces, name);
+        return new DataBuilderMeta(ImmutableSet.copyOf(consumes),
+        		ImmutableSet.copyOf(optionals),produces, name);
     }
 
+    
     public void setConsumes(Set<String> consumes) {
         this.consumes = consumes;
     }
-
+    
+    public void setOptionals(Set<String> optionals) {
+        this.optionals = optionals;
+    }
     public void setProduces(String produces) {
         this.produces = produces;
     }

--- a/src/test/java/com/flipkart/databuilderframework/ConditionalOptionalFlowTest.java
+++ b/src/test/java/com/flipkart/databuilderframework/ConditionalOptionalFlowTest.java
@@ -1,0 +1,99 @@
+package com.flipkart.databuilderframework;
+
+
+import com.flipkart.databuilderframework.engine.*;
+import com.flipkart.databuilderframework.engine.impl.InstantiatingDataBuilderFactory;
+import com.flipkart.databuilderframework.model.*;
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ConditionalOptionalFlowTest {
+	private DataBuilderMetadataManager dataBuilderMetadataManager = new DataBuilderMetadataManager();
+	private DataFlowExecutor executor = new SimpleDataFlowExecutor(new InstantiatingDataBuilderFactory(dataBuilderMetadataManager));
+	private ExecutionGraphGenerator executionGraphGenerator = new ExecutionGraphGenerator(dataBuilderMetadataManager);
+	private DataFlow dataFlow;
+	private DataFlow dataFlowError = new DataFlow();
+
+	// conditional builder here runs if C and D are present.
+	// if C == "Hello World"
+	// and D == "this" or G is present and G == this
+	public static final class ConditionalBuilder extends DataBuilder {
+
+		@Override
+		public Data process(DataBuilderContext context) throws DataBuilderException {
+			DataSetAccessor accessor = new DataSetAccessor(context.getDataSet());
+			TestDataC dataC = accessor.get("C", TestDataC.class);
+			TestDataD dataD = accessor.get("D", TestDataD.class);
+			Optional<TestDataG> dataGOptional = accessor.getOptional("G",TestDataG.class);
+
+			if(dataC.getValue().equals("Hello World")){
+				if( dataD.getValue().equalsIgnoreCase("this")) {
+					return new TestDataE("Wah wah!!");
+				}else if(dataGOptional.isPresent()){
+					TestDataG dataG = dataGOptional.get();
+					if(dataG.getValue().equalsIgnoreCase("this")){
+						return new TestDataE("Wah wah!!");
+					}
+				}
+
+			}
+			return null;
+		}
+	}
+
+	@Before
+	public void setup() throws Exception {
+		dataBuilderMetadataManager.register(ImmutableSet.of("A", "B"), "C", "BuilderA", TestBuilderA.class ); //concats A and B values
+		dataBuilderMetadataManager.register(ImmutableSet.of("C", "D"),ImmutableSet.of("G"), "E", "BuilderB", ConditionalBuilder.class );
+		dataBuilderMetadataManager.register(ImmutableSet.of("A", "E"), "F", "BuilderC", TestBuilderC.class );
+
+		dataFlow = new DataFlowBuilder()
+		.withMetaDataManager(dataBuilderMetadataManager)
+		.withTargetData("F")
+		.build();
+
+		dataFlowError = new DataFlowBuilder()
+		.withMetaDataManager(dataBuilderMetadataManager)
+		.withTargetData("Y")
+		.build();
+
+	}
+
+	@Test
+	public void testRunWithOptional() throws Exception {
+		DataFlowInstance dataFlowInstance = new DataFlowInstance();
+		dataFlowInstance.setId("testflow");
+		dataFlowInstance.setDataFlow(dataFlow);
+		{
+			DataDelta dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataA("Hello"), new TestDataB("World"), new TestDataD("notThis")));
+			DataExecutionResponse response = executor.run(dataFlowInstance, dataDelta);
+			Assert.assertTrue(response.getResponses().containsKey("C"));
+			Assert.assertFalse(response.getResponses().containsKey("E"));
+		}
+		{
+			DataDelta dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataG("notThis")));
+			DataExecutionResponse response = executor.run(dataFlowInstance, dataDelta);
+			Assert.assertFalse(response.getResponses().containsKey("E"));
+			Assert.assertFalse(response.getResponses().containsKey("C"));
+		}
+		{
+			DataDelta dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataG("this")));
+			DataExecutionResponse response = executor.run(dataFlowInstance, dataDelta);
+			Assert.assertTrue(response.getResponses().containsKey("E"));
+			Assert.assertTrue(response.getResponses().containsKey("F"));
+		}
+		{
+			DataDelta dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataD("this")));
+			DataExecutionResponse response = executor.run(dataFlowInstance, dataDelta);
+			Assert.assertTrue(response.getResponses().containsKey("E"));
+			Assert.assertTrue(response.getResponses().containsKey("F"));
+		}
+
+	}
+
+}

--- a/src/test/java/com/flipkart/databuilderframework/ConditionalOptionalFlowTest.java
+++ b/src/test/java/com/flipkart/databuilderframework/ConditionalOptionalFlowTest.java
@@ -29,13 +29,13 @@ public class ConditionalOptionalFlowTest {
 			DataSetAccessor accessor = new DataSetAccessor(context.getDataSet());
 			TestDataC dataC = accessor.get("C", TestDataC.class);
 			TestDataD dataD = accessor.get("D", TestDataD.class);
-			Optional<TestDataG> dataGOptional = accessor.getOptional("G",TestDataG.class);
+			Boolean isGPresent = accessor.checkForData("G");
 
 			if(dataC.getValue().equals("Hello World")){
 				if( dataD.getValue().equalsIgnoreCase("this")) {
 					return new TestDataE("Wah wah!!");
-				}else if(dataGOptional.isPresent()){
-					TestDataG dataG = dataGOptional.get();
+				}else if(isGPresent){
+					TestDataG dataG = accessor.get("G",TestDataG.class);
 					if(dataG.getValue().equalsIgnoreCase("this")){
 						return new TestDataE("Wah wah!!");
 					}

--- a/src/test/java/com/flipkart/databuilderframework/DataBuilderMetadataManagerOptionalTest.java
+++ b/src/test/java/com/flipkart/databuilderframework/DataBuilderMetadataManagerOptionalTest.java
@@ -1,0 +1,26 @@
+package com.flipkart.databuilderframework;
+
+import com.flipkart.databuilderframework.engine.DataBuilderFrameworkException;
+import com.flipkart.databuilderframework.engine.DataBuilderMetadataManager;
+import com.google.common.collect.ImmutableSet;
+
+import org.junit.Test;
+
+import static org.junit.Assert.fail;
+
+public class DataBuilderMetadataManagerOptionalTest {
+    @Test
+    public void testRegister() throws Exception {
+        DataBuilderMetadataManager dataBuilderMetadataManager
+                                        = new DataBuilderMetadataManager();
+        dataBuilderMetadataManager.register(ImmutableSet.of("A", "B"),ImmutableSet.of("G"), "C", "BuilderA", TestBuilderA.class );
+        try {
+            dataBuilderMetadataManager.register(ImmutableSet.of("A", "B"),ImmutableSet.of("G"), "C", "BuilderA", TestBuilderB.class );
+        } catch (DataBuilderFrameworkException e) {
+            if(e.getErrorCode() == DataBuilderFrameworkException.ErrorCode.BUILDER_EXISTS) {
+                return;
+            }
+        }
+        fail("Duplicate error should have come");
+    }
+}

--- a/src/test/java/com/flipkart/databuilderframework/DataFlowWithOptionalExecutorTest.java
+++ b/src/test/java/com/flipkart/databuilderframework/DataFlowWithOptionalExecutorTest.java
@@ -1,0 +1,213 @@
+package com.flipkart.databuilderframework;
+
+import com.flipkart.databuilderframework.engine.*;
+import com.flipkart.databuilderframework.engine.impl.InstantiatingDataBuilderFactory;
+import com.flipkart.databuilderframework.model.*;
+import com.google.common.collect.Lists;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.junit.Assert.fail;
+
+public class DataFlowWithOptionalExecutorTest {
+    private static class TestListener implements DataBuilderExecutionListener {
+
+        @Override
+        public void beforeExecute(DataFlowInstance dataFlowInstance,
+                                  DataBuilderMeta builderToBeApplied,
+                                  DataDelta dataDelta, Map<String, Data> prevResponses) throws Exception {
+            System.out.println(builderToBeApplied.getName() + " being called for: " + dataFlowInstance.getId());
+        }
+
+        @Override
+        public void afterExecute(DataFlowInstance dataFlowInstance,
+                                 DataBuilderMeta builderToBeApplied,
+                                 DataDelta dataDelta, Map<String, Data> prevResponses, Data currentResponse) throws Exception {
+            System.out.println(builderToBeApplied.getName() + " called for: " + dataFlowInstance.getId());
+        }
+
+        @Override
+        public void afterException(DataFlowInstance dataFlowInstance,
+                                   DataBuilderMeta builderToBeApplied,
+                                   DataDelta dataDelta,
+                                   Map<String, Data> prevResponses, Throwable frameworkException) throws Exception {
+            System.out.println(builderToBeApplied.getName() + " called for: " + dataFlowInstance.getId());
+        }
+    }
+    private static class TestListenerBeforeExecutionError implements DataBuilderExecutionListener {
+
+        @Override
+        public void beforeExecute(DataFlowInstance dataFlowInstance,
+                                  DataBuilderMeta builderToBeApplied,
+                                  DataDelta dataDelta, Map<String, Data> prevResponses) throws Exception {
+            //System.out.println(builderToBeApplied.getName() + " being called for: " + dataFlowInstance.getId());
+            throw new Exception("Blah blah");
+        }
+
+        @Override
+        public void afterExecute(DataFlowInstance dataFlowInstance,
+                                 DataBuilderMeta builderToBeApplied,
+                                 DataDelta dataDelta, Map<String, Data> prevResponses, Data currentResponse) throws Exception {
+            System.out.println(builderToBeApplied.getName() + " called for: " + dataFlowInstance.getId());
+        }
+
+        @Override
+        public void afterException(DataFlowInstance dataFlowInstance,
+                                   DataBuilderMeta builderToBeApplied,
+                                   DataDelta dataDelta,
+                                   Map<String, Data> prevResponses, Throwable frameworkException) throws Exception {
+            System.out.println(builderToBeApplied.getName() + " called for: " + dataFlowInstance.getId());
+        }
+    }
+    private static class TestListenerAfterExecutionError implements DataBuilderExecutionListener {
+
+        @Override
+        public void beforeExecute(DataFlowInstance dataFlowInstance,
+                                  DataBuilderMeta builderToBeApplied,
+                                  DataDelta dataDelta, Map<String, Data> prevResponses) throws Exception {
+            System.out.println(builderToBeApplied.getName() + " being called for: " + dataFlowInstance.getId());
+        }
+
+        @Override
+        public void afterExecute(DataFlowInstance dataFlowInstance,
+                                 DataBuilderMeta builderToBeApplied,
+                                 DataDelta dataDelta, Map<String, Data> prevResponses, Data currentResponse) throws Exception {
+            //System.out.println(builderToBeApplied.getName() + " called for: " + dataFlowInstance.getId());
+            throw new Exception("Blah blah");
+
+        }
+
+        @Override
+        public void afterException(DataFlowInstance dataFlowInstance,
+                                   DataBuilderMeta builderToBeApplied,
+                                   DataDelta dataDelta,
+                                   Map<String, Data> prevResponses, Throwable frameworkException) throws Exception {
+            System.out.println(builderToBeApplied.getName() + " called for: " + dataFlowInstance.getId());
+        }
+    }
+
+    private static class TestListenerAfterExceptionError implements DataBuilderExecutionListener {
+
+        @Override
+        public void beforeExecute(DataFlowInstance dataFlowInstance,
+                                  DataBuilderMeta builderToBeApplied,
+                                  DataDelta dataDelta, Map<String, Data> prevResponses) throws Exception {
+            System.out.println(builderToBeApplied.getName() + " being called for: " + dataFlowInstance.getId());
+        }
+
+        @Override
+        public void afterExecute(DataFlowInstance dataFlowInstance,
+                                 DataBuilderMeta builderToBeApplied,
+                                 DataDelta dataDelta, Map<String, Data> prevResponses, Data currentResponse) throws Exception {
+            System.out.println(builderToBeApplied.getName() + " called for: " + dataFlowInstance.getId());
+
+        }
+
+        @Override
+        public void afterException(DataFlowInstance dataFlowInstance,
+                                   DataBuilderMeta builderToBeApplied,
+                                   DataDelta dataDelta,
+                                   Map<String, Data> prevResponses, Throwable frameworkException) throws Exception {
+            //System.out.println(builderToBeApplied.getName() + " called for: " + dataFlowInstance.getId());
+            throw new Exception("Blah blah");
+        }
+    }
+
+    private DataBuilderMetadataManager dataBuilderMetadataManager = new DataBuilderMetadataManager();
+    private DataFlowExecutor executor = new SimpleDataFlowExecutor(new InstantiatingDataBuilderFactory(dataBuilderMetadataManager));
+    private DataFlow dataFlow = new DataFlow();
+
+    @Before
+    public void setup() throws Exception {
+        dataFlow = new DataFlowBuilder()
+                .withAnnotatedDataBuilder(TestBuilderOptional.class)
+                .withAnnotatedDataBuilder(TestBuilderB.class)
+                .withAnnotatedDataBuilder(TestBuilderC.class)
+                .withTargetData("F")
+                .build();
+
+    }
+
+    @Test
+    public void testRunWithoutOptional() throws Exception {
+        DataFlowInstance dataFlowInstance = new DataFlowInstance();
+        dataFlowInstance.setId("testflow");
+        dataFlowInstance.setDataFlow(dataFlow);
+        {
+            DataDelta dataDelta = new DataDelta(new TestDataB("World"));
+            DataExecutionResponse response = executor.run(dataFlowInstance, dataDelta);
+            Assert.assertTrue(response.getResponses().isEmpty());
+            Assert.assertFalse(response.getResponses().containsKey("C"));
+        }
+        {
+            DataDelta dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataA("Hello World")));
+            DataExecutionResponse response = executor.run(dataFlowInstance, dataDelta);
+            Assert.assertFalse(response.getResponses().isEmpty());
+            Assert.assertTrue(response.getResponses().containsKey("C"));
+        }
+        {
+            DataDelta dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataD("this")));
+            DataExecutionResponse response = executor.run(dataFlowInstance, dataDelta);
+            Assert.assertFalse(response.getResponses().isEmpty());
+            Assert.assertTrue(response.getResponses().containsKey("E"));
+            Assert.assertTrue(response.getResponses().containsKey("F"));
+        }
+    }
+
+    @Test
+    public void testRunOptional() throws Exception {
+        DataFlowInstance dataFlowInstance = new DataFlowInstance();
+        dataFlowInstance.setId("testflow");
+        dataFlowInstance.setDataFlow(dataFlow);
+        
+        {
+            DataDelta dataDelta = new DataDelta(new TestDataA("Hello"));
+            DataExecutionResponse response = executor.run(dataFlowInstance, dataDelta);
+            Assert.assertTrue(response.getResponses().isEmpty());
+            Assert.assertFalse(response.getResponses().containsKey("C"));
+        }
+        {
+            DataDelta dataDelta = new DataDelta(new TestDataB("World"));
+            DataExecutionResponse response = executor.run(dataFlowInstance, dataDelta);
+            Assert.assertFalse(response.getResponses().isEmpty());
+            Assert.assertTrue(response.getResponses().containsKey("C"));
+        }
+        {
+            DataDelta dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataD("this")));
+            DataExecutionResponse response = executor.run(dataFlowInstance, dataDelta);
+            Assert.assertFalse(response.getResponses().isEmpty());
+            Assert.assertTrue(response.getResponses().containsKey("E"));
+            Assert.assertTrue(response.getResponses().containsKey("F"));
+        }
+    }
+    @Test
+    public void testOptionalComingFirst() throws Exception {
+        DataFlowInstance dataFlowInstance = new DataFlowInstance();
+        dataFlowInstance.setId("testflow");
+        dataFlowInstance.setDataFlow(dataFlow);
+        {
+            DataDelta dataDelta = new DataDelta(new TestDataB("World"));
+            DataExecutionResponse response = executor.run(dataFlowInstance, dataDelta);
+            Assert.assertTrue(response.getResponses().isEmpty());
+            Assert.assertFalse(response.getResponses().containsKey("C"));
+        }
+        {
+            DataDelta dataDelta = new DataDelta(new TestDataA("Hello"));
+            DataExecutionResponse response = executor.run(dataFlowInstance, dataDelta);
+            Assert.assertFalse(response.getResponses().isEmpty());
+            Assert.assertTrue(response.getResponses().containsKey("C"));
+        }
+        {
+            DataDelta dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataD("this")));
+            DataExecutionResponse response = executor.run(dataFlowInstance, dataDelta);
+            Assert.assertFalse(response.getResponses().isEmpty());
+            Assert.assertTrue(response.getResponses().containsKey("E"));
+            Assert.assertTrue(response.getResponses().containsKey("F"));
+        }
+    }
+
+}

--- a/src/test/java/com/flipkart/databuilderframework/TestBuilderOptional.java
+++ b/src/test/java/com/flipkart/databuilderframework/TestBuilderOptional.java
@@ -6,9 +6,6 @@ import com.flipkart.databuilderframework.engine.DataBuilder;
 import com.flipkart.databuilderframework.engine.DataBuilderContext;
 import com.flipkart.databuilderframework.engine.DataSetAccessor;
 import com.flipkart.databuilderframework.model.Data;
-import com.flipkart.databuilderframework.optionaltest.TestDataA;
-import com.flipkart.databuilderframework.optionaltest.TestDataB;
-import com.flipkart.databuilderframework.optionaltest.TestDataC;
 import com.google.common.base.Optional;
 
 @DataBuilderInfo(name = "BuilderOptional", consumes = {"A"}, optionals= {"B"}, produces = "C")

--- a/src/test/java/com/flipkart/databuilderframework/TestBuilderOptional.java
+++ b/src/test/java/com/flipkart/databuilderframework/TestBuilderOptional.java
@@ -15,12 +15,12 @@ public class TestBuilderOptional extends DataBuilder {
     public Data process(DataBuilderContext context) {
         DataSetAccessor dataSetAccessor = context.getDataSet().accessor();
         TestDataA a = dataSetAccessor.get("A", TestDataA.class);
-        Optional<TestDataB> b = dataSetAccessor.getOptional("B", TestDataB.class);
+        boolean bIsPresent = dataSetAccessor.checkForData("B");
         if(a.getValue().contains(" ")){
         	return new TestDataC(a.getValue());
         }else{
-        	if(b.isPresent()){
-        		TestDataB bData = b.get();
+        	if(bIsPresent){
+        		TestDataB bData = dataSetAccessor.get("B",TestDataB.class);
         		return new TestDataC(a.getValue()+"_"+bData.getValue());
         	}
         }

--- a/src/test/java/com/flipkart/databuilderframework/TestBuilderOptional.java
+++ b/src/test/java/com/flipkart/databuilderframework/TestBuilderOptional.java
@@ -1,0 +1,32 @@
+package com.flipkart.databuilderframework;
+
+
+import com.flipkart.databuilderframework.annotations.DataBuilderInfo;
+import com.flipkart.databuilderframework.engine.DataBuilder;
+import com.flipkart.databuilderframework.engine.DataBuilderContext;
+import com.flipkart.databuilderframework.engine.DataSetAccessor;
+import com.flipkart.databuilderframework.model.Data;
+import com.flipkart.databuilderframework.optionaltest.TestDataA;
+import com.flipkart.databuilderframework.optionaltest.TestDataB;
+import com.flipkart.databuilderframework.optionaltest.TestDataC;
+import com.google.common.base.Optional;
+
+@DataBuilderInfo(name = "BuilderOptional", consumes = {"A"}, optionals= {"B"}, produces = "C")
+public class TestBuilderOptional extends DataBuilder {
+
+    @Override
+    public Data process(DataBuilderContext context) {
+        DataSetAccessor dataSetAccessor = context.getDataSet().accessor();
+        TestDataA a = dataSetAccessor.get("A", TestDataA.class);
+        Optional<TestDataB> b = dataSetAccessor.getOptional("B", TestDataB.class);
+        if(a.getValue().contains(" ")){
+        	return new TestDataC(a.getValue());
+        }else{
+        	if(b.isPresent()){
+        		TestDataB bData = b.get();
+        		return new TestDataC(a.getValue()+"_"+bData.getValue());
+        	}
+        }
+        return null;
+    }
+}

--- a/src/test/java/com/flipkart/databuilderframework/model/DataBuilderMetaTest.java
+++ b/src/test/java/com/flipkart/databuilderframework/model/DataBuilderMetaTest.java
@@ -1,69 +1,103 @@
 package com.flipkart.databuilderframework.model;
 
+import java.util.HashSet;
+
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+
 import org.junit.Assert;
 import org.junit.Test;
 
 public class DataBuilderMetaTest {
     @Test
-    public void testEquals() {
-        DataBuilderMeta lhs = new DataBuilderMeta(ImmutableSet.of("A", "B"), "C", "test");
-        DataBuilderMeta rhs = new DataBuilderMeta(ImmutableSet.of("A", "B"), "C", "test");
+    public void testEquals1() {
+        DataBuilderMeta lhs = new DataBuilderMeta(ImmutableSet.of("A", "B"), ImmutableSet.of("O"), "C", "test");
+        DataBuilderMeta rhs = new DataBuilderMeta(ImmutableSet.of("A", "B"), ImmutableSet.of("O"), "C", "test");
         Assert.assertEquals(lhs, rhs);
         Assert.assertEquals(lhs.hashCode(), rhs.hashCode());
     }
 
     @Test
+    public void testEquals2() {
+        DataBuilderMeta lhs = new DataBuilderMeta(ImmutableSet.of("A", "B"), new HashSet<String>(), "C", "test");
+        DataBuilderMeta rhs = new DataBuilderMeta(ImmutableSet.of("A", "B"), new HashSet<String>(), "C", "test");
+        Assert.assertEquals(lhs, rhs);
+        Assert.assertEquals(lhs.hashCode(), rhs.hashCode());
+    }
+
+    
+    @Test
     public void testNotEquals1() {
-        DataBuilderMeta lhs = new DataBuilderMeta(ImmutableSet.of("A", "B"), "C", "test");
-        DataBuilderMeta rhs = new DataBuilderMeta(ImmutableSet.of("A", "B"), "C", "test1");
+        DataBuilderMeta lhs = new DataBuilderMeta(ImmutableSet.of("A", "B"), ImmutableSet.of("O"), "C", "test");
+        DataBuilderMeta rhs = new DataBuilderMeta(ImmutableSet.of("A", "B"), ImmutableSet.of("O"), "C", "test1");
         Assert.assertFalse(lhs.equals(rhs));
     }
 
     @Test
     public void testNotEquals2() {
-        DataBuilderMeta lhs = new DataBuilderMeta(ImmutableSet.of("A", "B"), "C", "test");
-        DataBuilderMeta rhs = new DataBuilderMeta(ImmutableSet.of("A", "B"), "D", "test");
+        DataBuilderMeta lhs = new DataBuilderMeta(ImmutableSet.of("A", "B"), ImmutableSet.of("O"), "C", "test");
+        DataBuilderMeta rhs = new DataBuilderMeta(ImmutableSet.of("A", "B"), ImmutableSet.of("O"), "D", "test");
         Assert.assertFalse(lhs.equals(rhs));
     }
 
     @Test
     public void testNotEquals3() {
-        DataBuilderMeta lhs = new DataBuilderMeta(ImmutableSet.of("A", "B"), "C", "test");
-        DataBuilderMeta rhs = new DataBuilderMeta(ImmutableSet.of("A", "X"), "C", "test");
+        DataBuilderMeta lhs = new DataBuilderMeta(ImmutableSet.of("A", "B"), ImmutableSet.of("O"), "C", "test");
+        DataBuilderMeta rhs = new DataBuilderMeta(ImmutableSet.of("A", "X"), ImmutableSet.of("O"), "C", "test");
         Assert.assertFalse(lhs.equals(rhs));
     }
 
     @Test
+    public void testNotEquals9() {
+        DataBuilderMeta lhs = new DataBuilderMeta(ImmutableSet.of("A", "B"), ImmutableSet.of("O"), "C", "test");
+        DataBuilderMeta rhs = new DataBuilderMeta(ImmutableSet.of("A", "B"), ImmutableSet.of("D"), "C", "test");
+        Assert.assertFalse(lhs.equals(rhs));
+    }
+    
+    @Test
+    public void testNotEquals10() {
+        DataBuilderMeta lhs = new DataBuilderMeta(ImmutableSet.of("A", "B"), ImmutableSet.of("O"), "C", "test");
+        DataBuilderMeta rhs = new DataBuilderMeta(ImmutableSet.of("A", "B"), ImmutableSet.of("O","A"), "C", "test");
+        Assert.assertFalse(lhs.equals(rhs));
+    }
+    
+    @Test
+    public void testNotEquals11() {
+        DataBuilderMeta lhs = new DataBuilderMeta(ImmutableSet.of("A", "B"), ImmutableSet.of("O"), "C", "test");
+        DataBuilderMeta rhs = new DataBuilderMeta(ImmutableSet.of("A", "B"), ImmutableSet.of(""), "C", "test");
+        Assert.assertFalse(lhs.equals(rhs));
+    }
+    
+    @Test
     public void testNotEquals4() {
-        DataBuilderMeta lhs = new DataBuilderMeta(ImmutableSet.of("A", "B"), "C", "test");
-        DataBuilderMeta rhs = new DataBuilderMeta(ImmutableSet.of("A"), "D", "test");
+        DataBuilderMeta lhs = new DataBuilderMeta(ImmutableSet.of("A", "B"), ImmutableSet.of("O"),"C", "test");
+        DataBuilderMeta rhs = new DataBuilderMeta(ImmutableSet.of("A"), ImmutableSet.of("O"), "D", "test");
         Assert.assertFalse(lhs.equals(rhs));
     }
 
     @Test
     public void testNotEquals5() {
-        DataBuilderMeta lhs = new DataBuilderMeta(ImmutableSet.of("A", "B"), "C", "test");
-        DataBuilderMeta rhs = new DataBuilderMeta(ImmutableSet.of("A", "X"), "D", "test");
+        DataBuilderMeta lhs = new DataBuilderMeta(ImmutableSet.of("A", "B"),ImmutableSet.of("O"), "C", "test");
+        DataBuilderMeta rhs = new DataBuilderMeta(ImmutableSet.of("A", "X"),ImmutableSet.of("O"), "D", "test");
         Assert.assertFalse(lhs.equals(rhs));
         Assert.assertFalse(lhs.hashCode() == rhs.hashCode());
     }
 
     @Test
     public void testNotEquals6() {
-        DataBuilderMeta lhs = new DataBuilderMeta(ImmutableSet.of("A", "B"), "C", "test");
+        DataBuilderMeta lhs = new DataBuilderMeta(ImmutableSet.of("A", "B"),ImmutableSet.of("O"), "C", "test");
         Assert.assertTrue(lhs.equals(lhs));
     }
 
     @Test
     public void testNotEquals7() {
-        DataBuilderMeta lhs = new DataBuilderMeta(ImmutableSet.of("A", "B"), "C", "test");
+        DataBuilderMeta lhs = new DataBuilderMeta(ImmutableSet.of("A", "B"),ImmutableSet.of("O"), "C", "test");
         Assert.assertFalse(lhs.equals(null));
     }
 
     @Test
     public void testNotEquals8() {
-        DataBuilderMeta lhs = new DataBuilderMeta(ImmutableSet.of("A", "B"), "C", "test");
+        DataBuilderMeta lhs = new DataBuilderMeta(ImmutableSet.of("A", "B"),ImmutableSet.of("O"), "C", "test");
         Assert.assertFalse(lhs.equals(new Integer(100)));
     }
 

--- a/src/test/java/com/flipkart/databuilderframework/model/ExecutionGraphTest.java
+++ b/src/test/java/com/flipkart/databuilderframework/model/ExecutionGraphTest.java
@@ -19,7 +19,7 @@ public class ExecutionGraphTest {
     @Test
     public void testDeepCopy() throws Exception {
         List<DataBuilderMeta> builders = Lists.newArrayList(
-                                            new DataBuilderMeta(ImmutableSet.of("A", "B"), "C", "test"));
+                                            new DataBuilderMeta(ImmutableSet.of("A", "B"), ImmutableSet.of("O"), "C", "test"));
         ExecutionGraph executionGraph = new ExecutionGraph(Collections.singletonList(builders));
         ExecutionGraph executionGraph1 = executionGraph.deepCopy();
         Assert.assertArrayEquals(executionGraph.getDependencyHierarchy().get(0).toArray(new DataBuilderMeta[executionGraph.getDependencyHierarchy().size()]),

--- a/src/test/java/com/flipkart/databuilderframework/speed/AdditonRequestData.java
+++ b/src/test/java/com/flipkart/databuilderframework/speed/AdditonRequestData.java
@@ -1,0 +1,11 @@
+package com.flipkart.databuilderframework.speed;
+
+import com.flipkart.databuilderframework.model.Data;
+
+public class AdditonRequestData extends Data{
+
+	protected AdditonRequestData() {
+		super("ADD_REQ");
+	}
+
+}

--- a/src/test/java/com/flipkart/databuilderframework/speed/ConcurrencyWithOptionalsTest.java
+++ b/src/test/java/com/flipkart/databuilderframework/speed/ConcurrencyWithOptionalsTest.java
@@ -1,0 +1,69 @@
+package com.flipkart.databuilderframework.speed;
+
+import com.flipkart.databuilderframework.engine.*;
+import com.flipkart.databuilderframework.engine.impl.InstantiatingDataBuilderFactory;
+import com.flipkart.databuilderframework.model.*;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.concurrent.Executors;
+
+public class ConcurrencyWithOptionalsTest {
+    private DataBuilderMetadataManager dataBuilderMetadataManager = new DataBuilderMetadataManager();
+    private DataFlowExecutor executor = new MultiThreadedDataFlowExecutor(
+                                                new InstantiatingDataBuilderFactory(dataBuilderMetadataManager),
+                                                Executors.newFixedThreadPool(10));
+    private DataFlowExecutor simpleExecutor = new SimpleDataFlowExecutor(
+                                                new InstantiatingDataBuilderFactory(dataBuilderMetadataManager));
+    private ExecutionGraphGenerator executionGraphGenerator = new ExecutionGraphGenerator(dataBuilderMetadataManager);
+
+    @Before
+    public void setup() throws Exception {
+        dataBuilderMetadataManager.register(ImmutableSet.of("REQ"),ImmutableSet.of("ADD_REQ"), "A", "BuilderA", ServiceCallerA.class );
+        dataBuilderMetadataManager.register(ImmutableSet.of("REQ"),ImmutableSet.of("ADD_REQ"),  "B", "BuilderB", ServiceCallerB.class );
+        dataBuilderMetadataManager.register(ImmutableSet.of("REQ"),ImmutableSet.of("ADD_REQ"),  "C", "BuilderC", ServiceCallerC.class );
+        dataBuilderMetadataManager.register(ImmutableSet.of("REQ"),ImmutableSet.of("ADD_REQ"),  "D", "BuilderD", ServiceCallerD.class );
+        dataBuilderMetadataManager.register(ImmutableSet.of("ADD_REQ"),ImmutableSet.of("REQ"),  "E", "BuilderE", ServiceCallerE.class );
+        dataBuilderMetadataManager.register(ImmutableSet.of("REQ"),ImmutableSet.of("ADD_REQ"), "F", "BuilderF", ServiceCallerF.class );
+        dataBuilderMetadataManager.register(ImmutableSet.of("ADD_REQ"),ImmutableSet.of("REQ)"), "G", "BuilderG", ServiceCallerG.class );
+        dataBuilderMetadataManager.register(ImmutableSet.of("A", "B", "C", "D"), ImmutableSet.of("E","F","G"), "RES", "ResponseBuilder", DataCombiner.class );
+
+    }
+
+    @Test
+    public void testSpeed() throws Exception {
+        DataFlow dataFlow = new DataFlow();
+        dataFlow.setTargetData("RES");
+        ExecutionGraph executionGraph = executionGraphGenerator.generateGraph(dataFlow);
+        dataFlow.setExecutionGraph(executionGraph);
+
+        long mTime = 0 ;
+        for(int i = 0; i < 1000; i++) {
+            DataFlowInstance dataFlowInstance = new DataFlowInstance();
+            dataFlowInstance.setId("testflow");
+            dataFlowInstance.setDataFlow(dataFlow);
+            DataDelta dataDelta = new DataDelta(Lists.<Data>newArrayList(new RequestData()));
+            long startTime = System.currentTimeMillis();
+            DataExecutionResponse response = executor.run(dataFlowInstance, dataDelta);
+            mTime += (System.currentTimeMillis() - startTime);
+            Assert.assertEquals(5, response.getResponses().size());
+            //System.out.println("MT:" + System.currentTimeMillis());
+        }
+        long sTime = 0;
+        for(int i = 0; i < 1000; i++) {
+            DataFlowInstance dataFlowInstance = new DataFlowInstance();
+            dataFlowInstance.setId("testflow");
+            dataFlowInstance.setDataFlow(dataFlow);
+            DataDelta dataDelta = new DataDelta(Lists.<Data>newArrayList(new RequestData()));
+            long startTime = System.currentTimeMillis();
+            DataExecutionResponse response = simpleExecutor.run(dataFlowInstance, dataDelta);
+            sTime += (System.currentTimeMillis() - startTime);
+            Assert.assertEquals(5, response.getResponses().size());
+            //System.out.println("ST:" + System.currentTimeMillis());
+        }
+        System.out.println(String.format("MT: %d ST: %d", mTime, sTime));
+    }
+}


### PR DESCRIPTION
Made changes to include optionals - as a first class construct in databuilder.

Optional data completes the main consume data for cases where some attributes of consume data require more data for builder to execute. 
Hence builder would trigger if all consumes are present but may or may not produce data based on attributes in data that it consumed.

Optional data would trigger the builder only if all consumes data are in its data set and will support by providing additional information to enable builder to produce data.

Optional data enables having simple and small models for data and reduces using big data with many sub attributes. 